### PR TITLE
Use a timestamp instead of stat

### DIFF
--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -37,6 +37,7 @@ for conf_file in /etc/nginx/conf.d/*.conf*; do
                 error "Certbot failed for $primary_domain. Check the logs for details."
                 exit_code=1
             fi
+            echo $(date -d now +%s) > "/etc/letsencrypt/archive/$primary_domain/last_renewal"
         else
             echo "Not running certbot for $primary_domain; last renewal happened just recently."
         fi

--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -165,13 +165,13 @@ get_certificate() {
 # ran over a week ago or never happened yet), otherwise return false.
 is_renewal_required() {
     # If the file does not exist assume a renewal is required
-    last_renewal_file="/etc/letsencrypt/live/$1/privkey.pem"
+    last_renewal_file="/etc/letsencrypt/archive/$1/last_renewal"
     [ ! -e "$last_renewal_file" ] && return;
     
     # If the file exists, check if the last renewal was more than a week ago
     one_week_sec=604800
     now_sec=$(date -d now +%s)
-    last_renewal_sec=$(stat -c %Y "$last_renewal_file")
+    last_renewal_sec=$(cat "$last_renewal_file")
     last_renewal_delta_sec=$(( ($now_sec - $last_renewal_sec) ))
     is_finshed_week_sec=$(( ($one_week_sec - $last_renewal_delta_sec) ))
     [ $is_finshed_week_sec -lt 0 ]


### PR DESCRIPTION
Thanks for the excellent documentation. It was a huge help to me.

There were a couple of changes I found useful, and I figured I'd send you two PRs, in case you thought they were useful too.

This PR uses a file to store the last renewal timestamp, instead of using stat.

I do prefer the idea of using stat because it avoids having to create an extra file. But during development I found myself backing up and redeploying `nginx_secrets` and it messed with file modification times. The approach I ended up using is less neat, but possibly more practical. It offers potentially more use cases without affecting existing use cases. If you think it might be useful for other people, here it is.