### PR TITLE
Sixty days

### DIFF
--- a/src/scripts/entrypoint.sh
+++ b/src/scripts/entrypoint.sh
@@ -33,8 +33,8 @@ while [ true ]; do
     echo "Run certbot!"
     /scripts/run_certbot.sh
 
-    echo "Certbot will now sleep for 8 days..."
-    sleep 8d
+    echo "Certbot will now sleep for 15 days..."
+    sleep 15d
 done
 ) &
 

--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -38,7 +38,7 @@ for conf_file in /etc/nginx/conf.d/*.conf*; do
                 exit_code=1
             fi
         else
-            echo "Not running certbot for $primary_domain; last renewal happened just recently."
+            echo "Not running certbot for $primary_domain; renewal happened in the last 60 days."
         fi
     done
 done

--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -168,11 +168,11 @@ is_renewal_required() {
     last_renewal_file="/etc/letsencrypt/live/$1/privkey.pem"
     [ ! -e "$last_renewal_file" ] && return;
     
-    # If the file exists, check if the last renewal was more than a week ago
-    one_week_sec=604800
+    # If the file exists, check if the last renewal was more than 60 days ago
+    sixty_days_sec=5184000
     now_sec=$(date -d now +%s)
     last_renewal_sec=$(stat -c %Y "$last_renewal_file")
     last_renewal_delta_sec=$(( ($now_sec - $last_renewal_sec) ))
-    is_finshed_week_sec=$(( ($one_week_sec - $last_renewal_delta_sec) ))
-    [ $is_finshed_week_sec -lt 0 ]
+    to_sixty_days_sec=$(( ($sixty_days_sec - $last_renewal_delta_sec) ))
+    [ $to_sixty_days_sec -lt 0 ]
 }


### PR DESCRIPTION
This PR is an attempt to stick a bit closer to Let's Encrypt's best practices.

Instead of checking and renewing every week, it renews every 60 days, and checks every 15.
