### PR TITLE
Add `--cert-name` flag to certbot

### DIFF
--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -154,6 +154,7 @@ get_certificate() {
         --preferred-challenges http-01 \
         --email $2 \
         --server $letsencrypt_url \
+        --cert-name $1 \
         $3 \
         --debug
 }


### PR DESCRIPTION
This will allow users to both add and subtract domain names to
certificate files that already exists on disk. Without this an
error message would be printed if the requested domains were not
identical to the ones requested the previous time.

Fixes #13 