### PR TITLE
Ignore entries starting with "data:"

### DIFF
--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -62,7 +62,7 @@ allfiles_exist() {
     all_exist=0
     for type in keyfile fullchain chain dhparam; do
         for file in $(parse_"${type}"s $1); do
-            if [[ $file != data:* ]] && [ ! -f ${file} ]; then
+            if [[ $file != data:* ]] && [[ $file != engine:* ]] && [ ! -f ${file} ]; then
                 error "Couldn't find ${type} '${file}' for '$1'"
                 all_exist=1
             fi

--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -62,7 +62,7 @@ allfiles_exist() {
     all_exist=0
     for type in keyfile fullchain chain dhparam; do
         for file in $(parse_"${type}"s $1); do
-            if [ ! -f ${file} ]; then
+            if [[ $file != data:* ]] && [ ! -f ${file} ]; then
                 error "Couldn't find ${type} '${file}' for '$1'"
                 all_exist=1
             fi


### PR DESCRIPTION
Hi @valdergallo,

Thank you very much for this awesome project.

I had a problem with my conf files containing <code>data:<i>$variable</i></code> entries: they were renamed to `myfile.conf.nokey`.
This Pull Request adds a test to ignore files starting with `data:`

I included some explanation in the commit message:

> Since version 1.15.10, Nginx supports the loading of SSL certificates and secret keys from variables.
> From the documentation: "The value data:$variable can be specified instead of the file, which loads a certificate from a variable without using intermediate files."
>
> For example, this feature allows using an empty certificate for the "default" server: https://serverfault.com/a/1044022/111986

Best regards,
Benoit