### PR TITLE
Listen on IPv6 when redirecting HTTP -> HTTPS

### DIFF
--- a/src/nginx_conf.d/redirector.conf
+++ b/src/nginx_conf.d/redirector.conf
@@ -1,6 +1,7 @@
 server {
     # Listen on plain old HTTP and catch any hostname for redirect to HTTPS
     listen 80 default_server;
+    listen [::]:80 default_server;
 
     # Pass this particular URL off to the certbot server for it to be able to
     # authenticate with letsencrypt and get the HTTPS certificates.


### PR DESCRIPTION
When running on a dual-stack host, we can ask `nginx` to listen on IPv6 in our user configs, but the bundled configs should themselves listen on IPv6 when applicable.  My fork [has been doing this for a while](https://github.com/staticfloat/docker-nginx-certbot/blob/master/src/nginx_conf.d/certbot.conf) (along with specifying `reuseport` but I don't think that's so critical), so I don't believe there are any major incompatibilities involved with turning this on.