### PR TITLE
Add `reuseport` to redirector `listen` statements

### DIFF
--- a/src/nginx_conf.d/redirector.conf
+++ b/src/nginx_conf.d/redirector.conf
@@ -1,7 +1,7 @@
 server {
     # Listen on plain old HTTP and catch any hostname for redirect to HTTPS
-    listen 80 default_server;
-    listen [::]:80 default_server;
+    listen 80 default_server reuseport;
+    listen [::]:80 default_server reuseport;
 
     # Pass this particular URL off to the certbot server for it to be able to
     # authenticate with letsencrypt and get the HTTPS certificates.


### PR DESCRIPTION
This enables nginx's [socket sharding technique](https://www.nginx.com/blog/socket-sharding-nginx-release-1-9-1/), which improves latency and parallelization.  We don't expect the servers listening on port 80 to be handling massive amounts of traffic, but just in case, it's best to be doing things as well as possible.