### PR TITLE
Drop i386 arch for Alpine

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -77,7 +77,6 @@ jobs:
           file: ./src/Dockerfile-alpine
           platforms: |
             linux/amd64
-            linux/386
             linux/arm64
             linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build_tags.yml
+++ b/.github/workflows/build_tags.yml
@@ -81,7 +81,6 @@ jobs:
           file: ./src/Dockerfile-alpine
           platforms: |
             linux/amd64
-            linux/386
             linux/arm64
             linux/arm/v7
           pull: true


### PR DESCRIPTION
There are problems for the upstream images when they are trying to
build the i386 arch for Alpine, and there is no indication on when
this problem will be solved.

In order to not fall too far beind in Nginx updates we will drop
this arch for Alpine going forward.