### PR TITLE
Add support for DNS01 challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,16 @@ instructions, from `@staticfloat`'s image, can be found
 - `CERTBOT_EMAIL`: Your e-mail address. Used by Let's Encrypt to contact you in case of security issues.
 
 ### Optional
-- `STAGING`: Set to `1` to use Let's Encrypt's [staging servers](./docs/good_to_know.md#initial-testing) (default: `0`)
 - `DHPARAM_SIZE`: The size of the [Diffie-Hellman parameters](./docs/good_to_know.md#diffie-hellman-parameters) (default: `2048`)
-- `RSA_KEY_SIZE`: The size of the RSA encryption keys (default: `2048`)
 - `ELLIPTIC_CURVE`: The size/[curve][15] of the ECDSA keys (default: `secp256r1`)
-- `USE_ECDSA`: Set to `1` to have certbot use [ECDSA instead of RSA](./docs/good_to_know.md#ecdsa-and-rsa-certificates) (default: `0`)
 - `RENEWAL_INTERVAL`: Time interval between certbot's [renewal checks](./docs/good_to_know.md#renewal-check-interval) (default: `8d`)
+- `RSA_KEY_SIZE`: The size of the RSA encryption keys (default: `2048`)
+- `STAGING`: Set to `1` to use Let's Encrypt's [staging servers](./docs/good_to_know.md#initial-testing) (default: `0`)
+- `USE_ECDSA`: Set to `1` to have certbot use [ECDSA instead of RSA](./docs/good_to_know.md#ecdsa-and-rsa-certificates) (default: `0`)
 
 ### Advanced
+- `CERTBOT_AUTHENTICATOR`: The authenticator plugin (either a [dns plugin](https://eff-certbot.readthedocs.io/en/stable/using.html#dns-plugins) or `webroot`) to use by default when responding to challenges (default: `webroot`)
+- `CERTBOT_DNS_PROPAGATION_SECONDS`: The number of seconds to wait after a DNS challenge has been setup before asking Let's Encrypt to check it (default: certbot's default)
 - `DEBUG`: Set to `1` to enable debug messages and use the [`nginx-debug`][10] binary (default: `0`)
 - `USE_LOCAL_CA`: Set to `1` to enable the use of a [local certificate authority](./docs/advanced_usage.md#local-ca) (default: `0`)
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ instructions, from `@staticfloat`'s image, can be found
 - `USE_ECDSA`: Set to `1` to have certbot use [ECDSA instead of RSA](./docs/good_to_know.md#ecdsa-and-rsa-certificates) (default: `0`)
 
 ### Advanced
-- `CERTBOT_AUTHENTICATOR`: The authenticator plugin (either a [dns plugin](https://eff-certbot.readthedocs.io/en/stable/using.html#dns-plugins) or `webroot`) to use by default when responding to challenges (default: `webroot`)
+- `CERTBOT_AUTHENTICATOR`: The [authenticator plugin](./docs/certbot_authenticators.md) (either a [dns plugin](https://eff-certbot.readthedocs.io/en/stable/using.html#dns-plugins) or `webroot`) to use by default when responding to challenges (default: `webroot`)
 - `CERTBOT_DNS_PROPAGATION_SECONDS`: The number of seconds to wait after a DNS challenge has been setup before asking Let's Encrypt to check it (default: certbot's default)
 - `DEBUG`: Set to `1` to enable debug messages and use the [`nginx-debug`][10] binary (default: `0`)
 - `USE_LOCAL_CA`: Set to `1` to enable the use of a [local certificate authority](./docs/advanced_usage.md#local-ca) (default: `0`)

--- a/docs/certbot_authenticators.md
+++ b/docs/certbot_authenticators.md
@@ -1,0 +1,92 @@
+# Certbot Authenticators
+
+Certbot allows to use a number of [authenticators to get certificates][1]. By default, and this will be sufficient for most users, this container uses the [webroot authenticator][2], which will provision certificates for your domain names by doing what we call [HTTP-01 validation][3], where we prove ownership of the domain name by serving a specific content at a given URL.
+
+Among the other authenticators available to certbot, the [DNS authenticators][4] are also available through this container. DNS authenticators allow to prove ownership of a domain name by serving a challenge directly through a TXT record, added in your DNS provider, which is called [DNS-01][5]. As these challenges are a stronger proof of ownership than using HTTP-01, they also allow to provision wildcard certificates, that cover a whole subdomain layer of your domain (e.g. `*.example.com` covers `<anything>.example.com`, where `<anything>` can be... well... anything that is valid for DNS).
+
+
+## Setting up the container to use DNS-01 challenges
+
+To use DNS-01 challenges, you will need to create the credentials file for the chosen authenticator.
+
+You can find information about how to configure them by following those links for the supported authenticators:
+ - [dns-cloudflare][6]
+ - [dns-cloudxns][7]
+ - [dns-digitalocean][8]
+ - [dns-dnsimple][9]
+ - [dns-dnsmadeeasy][10]
+ - [dns-gehirn][11]
+ - [dns-google][12]
+ - [dns-linode][13]
+ - [dns-luadns][14]
+ - [dns-nsone][15]
+ - [dns-ovh][16]
+ - [dns-rfc2136][17]
+ - [dns-route53][18]
+ - [dns-sakuracloud][19]
+
+You will need to setup the authenticator file at `/etc/letsencrypt/<authenticator provider>.ini`.
+E.g. for Cloudflare, we would create the file `/etc/letsencrypt/cloudflare.ini` with the following content:
+
+```ini
+# Cloudflare API token used by Certbot
+dns_cloudflare_api_token = 0123456789abcdef0123456789abcdef01234567
+```
+
+
+## Using a DNS-01 authenticator by default
+
+You can use an authenticator solving DNS-01 challenges by default by setting the `CERTBOT_AUTHENTICATOR` environment variable in your docker configuration with for value the name of the authenticator you wish to use (e.g. `dns-cloudflare`).
+
+All the certificates needing renewal or creation will then start using that authenticator. Make sure, of course, that you've setup the authenticator correctly, as described above.
+
+
+## Using a DNS-01 authenticator for specific certificates only
+
+You might want to keep using the `webroot` authenticator in most cases, but need to use a DNS-01 challenge to setup a wildcard certificate for a given domain. Or you might even have a domain setup on Route53 while your other domains are on Cloudflare, and you thus are using `dns-cloudflare` as default authenticator.
+
+In such cases, you can specify the authenticator you wish to use in the certificate path that you are setting up as `ssl_certificate_key` in your server block of the nginx configuration. In our case, if we want to use `dns-route53` for a specific certificate, we could be using the following:
+
+```
+server {
+    listen              443 ssl;
+    server_name         yourdomain.org *.yourdomain.org;
+    ssl_certificate_key /etc/letsencrypt/live/test-name.dns-route53/privkey.pem;
+    ...
+}
+```
+
+The script ran in the container to renew certificates will automatically identify that it needs to use the Route53 authenticator here. Of course, you will need that authenticator to be configured properly in order to be able to use it.
+
+
+## DNS-01 challenges are failing even though I can see the challenges setup in my provider's configuration
+
+DNS propagation is usually quite fast, but depends a lot on caching. This means that if Let's Encrypt tried to read the challenge recently, it might still hit a cache returning an older value of the TXT record that was added by certbot.
+
+If this happens often to you, you can set the `CERTBOT_DNS_PROPAGATION_SECONDS` environment variable in your docker configuration, to increase the time to wait for DNS propagation to happen.
+
+When that environment variable is not set, certbot will use a default value, which can be found in the documentation of the authenticator of your chosing. At the time of writing, this default value is of 10 seconds for all of the DNS authenticators.
+
+
+
+
+[1]: https://eff-certbot.readthedocs.io/en/stable/using.html#id8
+[2]: https://eff-certbot.readthedocs.io/en/stable/using.html#webroot
+[3]: https://letsencrypt.org/docs/challenge-types/#http-01-challenge
+[4]: https://eff-certbot.readthedocs.io/en/stable/using.html#dns-plugins
+[5]: https://letsencrypt.org/docs/challenge-types/#dns-01-challenge
+[6]: https://certbot-dns-cloudflare.readthedocs.io/en/stable/#credentials
+[7]: https://certbot-dns-cloudxns.readthedocs.io/en/stable/#credentials
+[8]: https://certbot-dns-digitalocean.readthedocs.io/en/stable/#credentials
+[9]: https://certbot-dns-dnsimple.readthedocs.io/en/stable/#credentials
+[10]: https://certbot-dns-dnsmadeeasy.readthedocs.io/en/stable/#credentials
+[11]: https://certbot-dns-gehirn.readthedocs.io/en/stable/#credentials
+[12]: https://certbot-dns-google.readthedocs.io/en/stable/#credentials
+[13]: https://certbot-dns-linode.readthedocs.io/en/stable/#credentials
+[14]: https://certbot-dns-luadns.readthedocs.io/en/stable/#credentials
+[15]: https://certbot-dns-nsone.readthedocs.io/en/stable/#credentials
+[16]: https://certbot-dns-ovh.readthedocs.io/en/stable/#credentials
+[17]: https://certbot-dns-rfc2136.readthedocs.io/en/stable/#credentials
+[18]: https://certbot-dns-route53.readthedocs.io/en/stable/#credentials
+[19]: https://certbot-dns-sakuracloud.readthedocs.io/en/stable/#credentials
+

--- a/docs/certbot_authenticators.md
+++ b/docs/certbot_authenticators.md
@@ -56,8 +56,7 @@ server {
 }
 ```
 
-The script ran in the container to renew certificates will automatically identify that it needs to use the Route53 authenticator here. Of course, you will need that authenticator to be configured properly in order to be able to use it.
-
+The script ran in the container to renew certificates will automatically identify that it needs to use the Route53 authenticator here. Of course, you will need that authenticator to be configured properly in order to be able to use it. This setting is also compatible with the [multi-certificate setup](./advanced_usage.md#multi-certificate-setup).
 
 ## DNS-01 challenges are failing even though I can see the challenges setup in my provider's configuration
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -3,6 +3,22 @@ LABEL maintainer="Jonas Alfredsson <jonas.alfredsson@protonmail.com>"
 
 ARG BUILDX_QEMU_ENV
 
+ENV CERTBOT_DNS_AUTHENTICATORS \
+    cloudflare \
+    cloudxns \
+    digitalocean \
+    dnsimple \
+    dnsmadeeasy \
+    gehirn \
+    google \
+    linode \
+    luadns \
+    nsone \
+    ovh \
+    rfc2136 \
+    route53 \
+    sakuracloud
+
 # Do a single run command to make the intermediary containers smaller.
 RUN set -ex && \
 # Install packages necessary during the build phase (for all architectures).
@@ -28,6 +44,8 @@ RUN set -ex && \
     fi && \
 # Install certbot.
     pip3 install -U cffi certbot \
+# And the supported extra authenticators
+        $(echo $CERTBOT_DNS_AUTHENTICATORS | sed 's/\(^\| \)/\1certbot-dns-/g') \
     && \
 # Remove everything that is no longer necessary.
     apt-get remove --purge -y \

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -1,6 +1,22 @@
 FROM nginx:1.21.3-alpine
 LABEL maintainer="Jonas Alfredsson <jonas.alfredsson@protonmail.com>"
 
+ENV CERTBOT_DNS_AUTHENTICATORS \
+    cloudflare \
+    cloudxns \
+    digitalocean \
+    dnsimple \
+    dnsmadeeasy \
+    gehirn \
+    google \
+    linode \
+    luadns \
+    nsone \
+    ovh \
+    rfc2136 \
+    route53 \
+    sakuracloud
+
 # Do a single run command to make the intermediary containers smaller.
 RUN set -ex && \
 # Install packages necessary during the build phase (for all architectures).
@@ -25,6 +41,8 @@ RUN set -ex && \
     curl -L 'https://bootstrap.pypa.io/get-pip.py' | python3 && \
 # Install certbot.
     pip3 install -U cffi certbot \
+# And the supported extra authenticators
+        $(echo $CERTBOT_DNS_AUTHENTICATORS | sed 's/\(^\| \)/\1certbot-dns-/g') \
     && \
 # Remove everything that is no longer necessary.
     apk del \

--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -115,7 +115,7 @@ for conf_file in /etc/nginx/conf.d/*.conf*; do
         fi
 
         # Determine the authenticator to use to solve the challenge
-        if [[ "${cert_name,,}" =~ (^|[^a-z0-9])(dns-($(echo ${CERTBOT_DNS_AUTHENTICATORS} | sed 's/ /|/g')))([^a-z0-9]|$) ]]; then
+        if [[ "${cert_name,,}" =~ (^|[-.])(dns-($(echo ${CERTBOT_DNS_AUTHENTICATORS} | sed 's/ /|/g')))([-.]|$) ]]; then
             authenticator=${BASH_REMATCH[2]}
             debug "Found mention of authenticator '${authenticator}' in name '${cert_name}'"
         else

--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -51,35 +51,36 @@ fi
 # $3: Type of key algorithm to use (rsa or ecdsa)
 # $4: The authenticator to use to solve the challenge
 get_certificate() {
+    local authenticator="${4,,}"
     local authenticator_params=
     local challenge_type=
 
-    if [[ "${4,,}" == dns-* ]] && [[ ${CERTBOT_DNS_AUTHENTICATORS} =~ (^| )${4,,#dns-}( |$) ]]; then
-        local provider="${4,,#dns-}"
+    if [[ "$authenticator" == dns-* ]] && [[ ${CERTBOT_DNS_AUTHENTICATORS} =~ (^| )${authenticator#dns-}( |$) ]]; then
+        local provider="${authenticator#dns-}"
         local configfile="/etc/letsencrypt/${provider}.ini"
         if [ ! -f "$configfile" ]; then
-            error "Authenticator is '${4,,}' but '${configfile}' is missing"
+            error "Authenticator is '${authenticator}' but '${configfile}' is missing"
             return 1
         fi
 
         challenge_type="dns-01"
-        authenticator_params="--${4,,}-credentials=${configfile}"
+        authenticator_params="--${authenticator}-credentials=${configfile}"
         if [ -n "${CERTBOT_DNS_PROPAGATION_SECONDS}" ]; then
-            authenticator_params="${authenticator_params} --${4,,}-propagation-seconds=${CERTBOT_DNS_PROPAGATION_SECONDS}"
+            authenticator_params="${authenticator_params} --${authenticator}-propagation-seconds=${CERTBOT_DNS_PROPAGATION_SECONDS}"
         fi
-    elif [ "${4,,}" == "webroot" ]; then
+    elif [ "${authenticator}" == "webroot" ]; then
         challenge_type="http-01"
         authenticator_params="--webroot-path=/var/www/letsencrypt"
     else
-        error "Unknown authenticator '${4,,}' for '${1}'"
+        error "Unknown authenticator '${authenticator}' for '${1}'"
         return 1
     fi
 
-    info "Requesting an ${3^^} certificate for '${1}' (${challenge_type} through ${4,,})"
+    info "Requesting an ${3^^} certificate for '${1}' (${challenge_type} through ${authenticator})"
     certbot certonly \
         --agree-tos --keep -n --text \
         --preferred-challenges ${challenge_type} \
-        --authenticator ${4,,} \
+        --authenticator ${authenticator} \
         ${authenticator_params} \
         --email "${CERTBOT_EMAIL}" \
         --server "${letsencrypt_url}" \

--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -114,7 +114,7 @@ for conf_file in /etc/nginx/conf.d/*.conf*; do
         fi
 
         # Determine the authenticator to use to solve the challenge
-        if [[ "${cert_name,,}" =~ ^.*(-|\.)(dns-($(echo ${CERTBOT_DNS_AUTHENTICATORS} | sed 's/ /|/g'))).*$ ]]; then
+        if [[ "${cert_name,,}" =~ (^|[^a-z0-9])(dns-($(echo ${CERTBOT_DNS_AUTHENTICATORS} | sed 's/ /|/g')))([^a-z0-9]|$) ]]; then
             authenticator=${BASH_REMATCH[2]}
             debug "Found mention of authenticator '${authenticator}' in name '${cert_name}'"
         else

--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -54,33 +54,32 @@ get_certificate() {
     local authenticator_params=
     local challenge_type=
 
-    if [[ "$4" == dns-* ]] && \
-            [[ ${CERTBOT_DNS_AUTHENTICATORS} =~ (^| )${4#dns-}( |$) ]]; then
-        local provider="${4#dns-}"
+    if [[ "${4,,}" == dns-* ]] && [[ ${CERTBOT_DNS_AUTHENTICATORS} =~ (^| )${4,,#dns-}( |$) ]]; then
+        local provider="${4,,#dns-}"
         local configfile="/etc/letsencrypt/${provider}.ini"
         if [ ! -f "$configfile" ]; then
-            error "Authenticator is ${4} but ${configfile} is missing"
+            error "Authenticator is '${4,,}' but '${configfile}' is missing"
             return 1
         fi
 
         challenge_type="dns-01"
-        authenticator_params="--${4}-credentials=${configfile}"
+        authenticator_params="--${4,,}-credentials=${configfile}"
         if [ -n "${CERTBOT_DNS_PROPAGATION_SECONDS}" ]; then
-            authenticator_params="${authenticator_params} --${4}-propagation-seconds=${CERTBOT_DNS_PROPAGATION_SECONDS}"
+            authenticator_params="${authenticator_params} --${4,,}-propagation-seconds=${CERTBOT_DNS_PROPAGATION_SECONDS}"
         fi
-    elif [ "$4" == "webroot" ]; then
+    elif [ "${4,,}" == "webroot" ]; then
         challenge_type="http-01"
         authenticator_params="--webroot-path=/var/www/letsencrypt"
     else
-        error "Unknown authenticator ${4} for '${1}'"
+        error "Unknown authenticator '${4,,}' for '${1}'"
         return 1
     fi
 
-    info "Requesting an ${3^^} certificate for '${1}' (${challenge_type} through ${4})"
+    info "Requesting an ${3^^} certificate for '${1}' (${challenge_type} through ${4,,})"
     certbot certonly \
         --agree-tos --keep -n --text \
         --preferred-challenges ${challenge_type} \
-        --authenticator ${4} \
+        --authenticator ${4,,} \
         ${authenticator_params} \
         --email "${CERTBOT_EMAIL}" \
         --server "${letsencrypt_url}" \


### PR DESCRIPTION
Created another Dockerfile, pretty much a copy of the normal one, but with dns-cloudflare support so the DNS01 challenge type can be used, and support for wildcard certificates is also possible.