### PR TITLE
Wrote docs for using a wildcard certificate

### DIFF
--- a/docs/certbot_authenticators.md
+++ b/docs/certbot_authenticators.md
@@ -2,7 +2,7 @@
 
 Certbot allows to use a number of [authenticators to get certificates][1]. By default, and this will be sufficient for most users, this container uses the [webroot authenticator][2], which will provision certificates for your domain names by doing what we call [HTTP-01 validation][3], where we prove ownership of the domain name by serving a specific content at a given URL.
 
-Among the other authenticators available to certbot, the [DNS authenticators][4] are also available through this container. DNS authenticators allow to prove ownership of a domain name by serving a challenge directly through a TXT record, added in your DNS provider, which is called [DNS-01][5]. As these challenges are a stronger proof of ownership than using HTTP-01, they also allow to provision wildcard certificates, that cover a whole subdomain layer of your domain (e.g. `*.example.com` covers `<anything>.example.com`, where `<anything>` can be... well... anything that is valid for DNS).
+Among the other authenticators available to certbot, the [DNS authenticators][4] are also available through this container. DNS authenticators allow to prove ownership of a domain name by serving a challenge directly through a TXT record, added in your DNS provider, which is called [DNS-01][5]. As these challenges are a stronger proof of ownership than using HTTP-01, they also allow to provision [wildcard certificates](wildcard_cert.md), that cover a whole subdomain layer of your domain (e.g. `*.example.com` covers `<anything>.example.com`, where `<anything>` can be... well... anything that is valid for DNS).
 
 
 ## Setting up the container to use DNS-01 challenges

--- a/docs/wildcard_cert.md
+++ b/docs/wildcard_cert.md
@@ -55,3 +55,5 @@ server {
   add_header Content-Type text/plain;
 }
 ```
+
+Note that the certs referenced in the include will need to have been created first or Nginx will panic. You can do this by disabling (move or rename) your subdomain conf files, then start the container and wait for it to create the wildcard cert, then reenable the subdomains and restart the container.

--- a/docs/wildcard_cert.md
+++ b/docs/wildcard_cert.md
@@ -29,6 +29,18 @@ server {
 }
 ```
 
+This would prevent use of example.com; if you're using the base domain as well, you can either move it to its own conf file or, to keep the certs together, replace the `ssl_reject_handshake` above with:
+
+```nginx
+  if ($host != example.com) {
+    # Close the connection
+    return 444;
+  }
+
+  return 200 "Hello from example.com";
+  add_header Content-Type text/plain;
+```
+
 **/etc/nginx/includes/ssl**
 
 ```nginx

--- a/docs/wildcard_cert.md
+++ b/docs/wildcard_cert.md
@@ -1,0 +1,57 @@
+# Wildcard Certificates
+
+The certbot script will automatically request a certificate for each conf file that references one using the domains in `server_name`. To use a single wildcard cert with [DNS validation](certbot_authenticators.md) instead, set up a default site as usual, then create an _include file_ with the same cert that can be used for the subdomains (using the same `ssl_certificate_key` in two conf files will cause the cert to be overwritten with different domains; see [#91](https://github.com/JonasAlfredsson/docker-nginx-certbot/issues/91)).
+
+For example, with /etc/nginx/includes mounted to a folder on the host in additon to user_conf.d:
+
+**/etc/nginx/user_conf.d/default.conf**
+
+```nginx
+server {
+  # Listen to port 443 on both IPv4 and IPv6.
+  listen 443 ssl default_server reuseport;
+  listen [::]:443 ssl default_server reuseport;
+
+  # Domain names this server should respond to.
+  server_name example.com *.example.com;
+
+  # Load the certificate files.
+  ssl_certificate         /etc/letsencrypt/live/default/fullchain.pem;
+  ssl_certificate_key     /etc/letsencrypt/live/default/privkey.pem;
+  ssl_trusted_certificate /etc/letsencrypt/live/default/chain.pem;
+
+  # Load the Diffie-Hellman parameter.
+  ssl_dhparam /etc/letsencrypt/dhparams/dhparam.pem;
+
+  # Reject the request (alternatively, `return 444;` to trigger ERR_EMPTY_RESPONSE but with valid SSL)
+  # https://github.com/JonasAlfredsson/docker-nginx-certbot/blob/master/docs/nginx_tips.md#reject-unknown-server-name
+  ssl_reject_handshake on;
+}
+```
+
+**/etc/nginx/includes/ssl**
+
+```nginx
+listen 443;
+
+# Load the certificate files.
+ssl_certificate         /etc/letsencrypt/live/default/fullchain.pem;
+ssl_certificate_key     /etc/letsencrypt/live/default/privkey.pem;
+ssl_trusted_certificate /etc/letsencrypt/live/default/chain.pem;
+
+# Load the Diffie-Hellman parameter.
+ssl_dhparam /etc/letsencrypt/dhparams/dhparam.pem;
+```
+
+**/etc/nginx/user_conf.d/foo.conf**
+
+```nginx
+server {
+  include includes/ssl;
+
+  server_name foo.example.com;
+
+  return 200 "Hello";
+  add_header Content-Type text/plain;
+}
+```


### PR DESCRIPTION
From our conversation in #91. I'm not sure if we'd want to keep this if the script is modified to map cert→domains (and/or the `-wildcard` approach @XaF mentioned in #92), but it's something for the meantime (and if nothing else, it shows how to move the shared ssl bit to an include). I'd understand if you don't want to officially support wildcards yet until it can be better handled, though.