### PR TITLE
Use git via CLI when building with rust

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -17,6 +17,11 @@ ENV CERTBOT_DNS_AUTHENTICATORS \
     route53 \
     sakuracloud
 
+# Workaround for https://github.com/rust-lang/cargo/issues/9187
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+ENV CARGO_HTTP_DEBUG=true
+ENV CARGO_LOG=trace
+
 # Do a single run command to make the intermediary containers smaller.
 RUN set -ex && \
 # Install packages necessary during the build phase (for all architectures).
@@ -25,6 +30,7 @@ RUN set -ex && \
             build-essential \
             cargo \
             curl \
+            git \
             libffi7 \
             libffi-dev \
             libssl-dev \
@@ -36,6 +42,7 @@ RUN set -ex && \
 # Install the latest version of PIP, Setuptools and Wheel.
     curl -L 'https://bootstrap.pypa.io/get-pip.py' | python3 && \
 # Install certbot.
+    pip --version && cargo --version --verbose && \
     pip3 install -U cffi certbot \
 # And the supported extra authenticators
         $(echo $CERTBOT_DNS_AUTHENTICATORS | sed 's/\(^\| \)/\1certbot-dns-/g') \
@@ -45,6 +52,7 @@ RUN set -ex && \
             build-essential \
             cargo \
             curl \
+            git \
             libffi-dev \
             libssl-dev \
             python3-dev \

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -17,6 +17,11 @@ ENV CERTBOT_DNS_AUTHENTICATORS \
     route53 \
     sakuracloud
 
+# Workaround for https://github.com/rust-lang/cargo/issues/9187
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+ENV CARGO_HTTP_DEBUG=true
+ENV CARGO_LOG=trace
+
 # Do a single run command to make the intermediary containers smaller.
 RUN set -ex && \
 # Install packages necessary during the build phase (for all architectures).
@@ -24,6 +29,7 @@ RUN set -ex && \
         cargo \
         curl \
         findutils \
+        git \
         libffi \
         libffi-dev \
         libressl \
@@ -40,6 +46,7 @@ RUN set -ex && \
 # Install the latest version of PIP, Setuptools and Wheel.
     curl -L 'https://bootstrap.pypa.io/get-pip.py' | python3 && \
 # Install certbot.
+    pip3 --version && cargo --version --verbose && \
     pip3 install -U cffi certbot \
 # And the supported extra authenticators
         $(echo $CERTBOT_DNS_AUTHENTICATORS | sed 's/\(^\| \)/\1certbot-dns-/g') \
@@ -48,6 +55,7 @@ RUN set -ex && \
     apk del \
         cargo \
         curl \
+        git \
         libffi-dev \
         libressl-dev \
         python3-dev \


### PR DESCRIPTION
We get random errors, when rust is building, stating that

  failed to fetch https://github.com/rust-lang/crates.io-index

This appears to [be known][1] and will be fixed in the future. Until
then the suggested workaround is to use git that is installed on the
system instead.

[1]: https://github.com/rust-lang/cargo/issues/9187