### PR TITLE
Pull bash<5.1 ONLY from Alpine v3.12 Repository

### DIFF
--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -35,8 +35,7 @@ RUN set -ex && \
         sed \
     && \
 # Because of the bug mentioned in issue #42 we must use Bash <5.1.x for now.
-    echo 'http://dl-cdn.alpinelinux.org/alpine/v3.12/main' >> /etc/apk/repositories && \
-    apk add --no-cache 'bash<5.1' && \
+    apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.12/main/ 'bash<5.1' && \
 # Install the latest version of PIP, Setuptools and Wheel.
     curl -L 'https://bootstrap.pypa.io/get-pip.py' | python3 && \
 # Install certbot.


### PR DESCRIPTION
This change ONLY downloads bash<5.1 from the Alpine v3.12 repository via
a command line switch, rather than adds the repository to apk's
configuration, ie in the config file '/etc/apk/repositories'.

Doing this prevents very weird dependency version bugs that occur when
Alpine containers that derive from 'jonasal/nginx-certbot:*-alpine' run
apk to add packages. We would expect packages from the actual version of
Alpine used (v3.15 as of this writing), but instead gets packages from
v3.12.