### PR TITLE
Correctly recover from interrupted `dhparam` generation

### DIFF
--- a/src/scripts/create_dhparams.sh
+++ b/src/scripts/create_dhparams.sh
@@ -45,7 +45,7 @@ create_dhparam() {
 # Find any mentions of Diffie-Hellman parameters and create them if missing.
 for conf_file in /etc/nginx/conf.d/*.conf*; do
     for dh_file in $(parse_dhparams "${conf_file}"); do
-        if [ ! -f "${dh_file}" ] || ! grep -q "BEGIN DH PARAMETERS" "${dh_file}"; then
+        if [ ! -f "${dh_file}" ] || ! grep -q "END DH PARAMETERS" "${dh_file}"; then
             warning "Couldn't find the dhparam file '${dh_file}'; creating it..."
             mkdir -vp "$(dirname "${dh_file}")"
             rm -f "${dh_file}"

--- a/src/scripts/create_dhparams.sh
+++ b/src/scripts/create_dhparams.sh
@@ -45,9 +45,10 @@ create_dhparam() {
 # Find any mentions of Diffie-Hellman parameters and create them if missing.
 for conf_file in /etc/nginx/conf.d/*.conf*; do
     for dh_file in $(parse_dhparams "${conf_file}"); do
-        if [ ! -f "${dh_file}" ]; then
+        if [ ! -f "${dh_file}" ] || ! grep -q "BEGIN DH PARAMETERS" "${dh_file}"; then
             warning "Couldn't find the dhparam file '${dh_file}'; creating it..."
             mkdir -vp "$(dirname "${dh_file}")"
+            rm -f "${dh_file}"
             create_dhparam "${dh_file}"
             chmod 600 "${dh_file}"
         fi


### PR DESCRIPTION
I had a bad config that ended up killing the docker container before
`dhparam` generation finished, leaving a zero-length `dhaparam.pem` file.
This resulted in all future runs failing with an `nginx` panic.  This PR
decreases the likelihood of us getting stuck in such a loop by searching
for the `BEGIN DH PARAMETERS` header in a dhparams PEM file.