### PR TITLE
Listen on IPv6 for ACME challenge response

### DIFF
--- a/src/nginx_conf.d/certbot.conf
+++ b/src/nginx_conf.d/certbot.conf
@@ -2,6 +2,7 @@ server {
     # Listen only on port 81 for localhost, and nothing else.
     server_name 127.0.0.1;
     listen 127.0.0.1:81 default_server;
+    listen [::1]:81 default_server;
 
     charset utf-8;
 

--- a/src/nginx_conf.d/certbot.conf
+++ b/src/nginx_conf.d/certbot.conf
@@ -1,6 +1,5 @@
 server {
     # Listen only on port 81 for localhost, and nothing else.
-    server_name 127.0.0.1;
     listen 127.0.0.1:81 default_server;
     listen [::1]:81 default_server;
 


### PR DESCRIPTION
I'm using podman which allows for container networks that are IPv6 only. When using this container as part of the docker-compose setup in a [Nakama guide](https://www.snopekgames.com/tutorial/2021/how-host-nakama-server-10mo), I'm unable to get a certificate because the acme-challenge fails. This is because the nginx proxy locally from /.well-known/acme-challenge to localhost:81 returns a 502 Bad Gateway because nginx is [not listening on IPv6 for port 81](https://github.com/JonasAlfredsson/docker-nginx-certbot/blob/master/src/nginx_conf.d/certbot.conf#L4). This issue is not reproducible using docker as a backend because [docker doesn't support IPv6 only networks](https://github.com/moby/moby/issues/32850)

<details>
<summary>A minimal setup to reproduce is to use this nginx configuration which pulls the relevant configs from this repo: (Click to dropdown)</summary>
<pre>
user  nginx;
worker_processes  auto;

error_log  /var/log/nginx/error.log notice;
pid        /var/run/nginx.pid;


events {
    worker_connections  1024;
}


http {
    include       /etc/nginx/mime.types;
    default_type  application/octet-stream;

    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                      '$status $body_bytes_sent "$http_referer" '
                      '"$http_user_agent" "$http_x_forwarded_for"';

    access_log  /var/log/nginx/access.log  main;

    sendfile        on;
    #tcp_nopush     on;

    keepalive_timeout  65;

    #gzip  on;

	server {
	  server_name 127.0.0.1;
	  listen 127.0.0.1:81 default_server;
	  listen [::1]:81 default_server;
	  charset utf-8;
	  location ^~ /.well-known/acme-challenge {
	    default_type text/plain;A minimal setup to reproduce is to use this nginx configuration which pulls the relevant configs from this repo:

	    default_type "text/plain";
	    proxy_pass http://localhost:81;
	  }
	  location / {
	    return 301 http://example.com;
	  }
	}
}
</pre>
</details>

On a regular network you get the following behaviour:
```
root@host# podman run --rm --name test-nginx  -v $(pwd)/nginx.conf:/etc/nginx/nginx.conf:ro -d docker.io/library/nginx
root@host# podman exec -it test-nginx /bin/bash
root@container:/# curl -o /dev/null -s -w "%{http_code}\n" localhost
301
root@container:/# curl -o /dev/null -s -w "%{http_code}\n" localhost:81
404
root@container:/# curl -o /dev/null -s -w "%{http_code}\n" localhost/.well-known/acme-challenge
404
```

To create an IPv6 only network you can use the following command:
```
podman network create podmanv6 --subnet fd00:1::/112
```

The behaviour with this network is as follows:
```
root@host# podman run --network podmanv6 --rm --name test-nginx  -v $(pwd)/nginx.conf:/etc/nginx/nginx.conf:ro -d docker.io/library/nginx
root@host# podman exec -it test-nginx /bin/bash
root@container:/# curl -o /dev/null -s -w "%{http_code}\n" localhost
301
root@container:/# curl -o /dev/null -s -w "%{http_code}\n" localhost:81
404
root@container:/# curl -o /dev/null -s -w "%{http_code}\n" localhost/.well-known/acme-challenge
502
```

I've also built and pushed a version of this repo with my change to dockerhub at
meptl/nginx-certbot:latest.

Can I get a test for regressions on docker and a regular network? I can also do it, but I have to spin up a new dual-stack server.