### PR TITLE
Test nginx configuration before reload

### DIFF
--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -169,5 +169,11 @@ done
 # did indeed get certificates for.
 auto_enable_configs
 
+# Make sure the Nginx configs are valid.
+if ! nginx -t; then
+  error "Nginx configuration is invalid, skipped reloading. Check the logs for details."
+  exit 0
+fi
+
 # Finally, tell Nginx to reload the configs.
 nginx -s reload

--- a/src/scripts/run_local_ca.sh
+++ b/src/scripts/run_local_ca.sh
@@ -247,5 +247,11 @@ done
 # did indeed succeed with.
 auto_enable_configs
 
+# Make sure the Nginx configs are valid.
+if ! nginx -t; then
+  error "Nginx configuration is invalid, skipped reloading. Check the logs for details."
+  exit 0
+fi
+
 # Finally, tell Nginx to reload the configs.
 nginx -s reload


### PR DESCRIPTION
Test the nginx configuration before reloading. This avoids crashing the container if there are configuration errors.

This makes the behavior similar to [the nginx systemctl service](https://www.nginx.com/resources/wiki/start/topics/examples/systemd/) which tests the nginx configuration before reload to avoid the same issue.

```
ExecStartPre=/usr/sbin/nginx -t
```

Fixes #206.

Log output on valid configuration:

```
examples-nginx-certbot-1  | 2023/09/22 21:28:36 [info] Received SIGHUP signal; terminating the autorenewal sleep process
examples-nginx-certbot-1  | Terminated
examples-nginx-certbot-1  | 2023/09/22 21:28:36 [info] Running the autorenewal service
examples-nginx-certbot-1  | 2023/09/22 21:28:36 [info] Starting certificate renewal process
examples-nginx-certbot-1  | nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
examples-nginx-certbot-1  | nginx: configuration file /etc/nginx/nginx.conf test is successful
examples-nginx-certbot-1  | 2023/09/22 21:28:36 [notice] 407#407: signal process started
examples-nginx-certbot-1  | 2023/09/22 21:28:36 [notice] 68#68: signal 1 (SIGHUP) received from 407, reconfiguring
examples-nginx-certbot-1  | 2023/09/22 21:28:36 [notice] 68#68: reconfiguring
examples-nginx-certbot-1  | 2023/09/22 21:28:36 [info] Autorenewal service will now sleep 8d
```

Log output on invalid configuration:

```
examples-nginx-certbot-1  | 2023/09/22 21:29:09 [info] Received SIGHUP signal; terminating the autorenewal sleep process
examples-nginx-certbot-1  | Terminated
examples-nginx-certbot-1  | 2023/09/22 21:29:09 [info] Running the autorenewal service
examples-nginx-certbot-1  | 2023/09/22 21:29:09 [info] Starting certificate renewal process
examples-nginx-certbot-1  | 2023/09/22 21:29:09 [emerg] 321#321: unexpected end of file, expecting ";" or "}" in /etc/nginx/conf.d/example_server.conf:10
examples-nginx-certbot-1  | nginx: [emerg] unexpected end of file, expecting ";" or "}" in /etc/nginx/conf.d/example_server.conf:10
examples-nginx-certbot-1  | nginx: configuration file /etc/nginx/nginx.conf test failed
examples-nginx-certbot-1  | 
examples-nginx-certbot-1  | 
examples-nginx-certbot-1  | 2023/09/22 21:29:09 [error] Nginx configuration is invalid, skipped reloading. Check the logs for details.
examples-nginx-certbot-1  | 
examples-nginx-certbot-1  | 2023/09/22 21:29:09 [info] Autorenewal service will now sleep 8d
```
