### PR TITLE
Mount nginx_secrets volume on host with directory binding

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -17,3 +17,11 @@ services:
 
 volumes:
   nginx_secrets:
+  # Uncomment and mount on the host after creating the directory.
+  #   driver: local
+  #   driver_opts:
+  #     type: none
+  #     o: bind
+  #     device: ./nginx_secrets
+
+


### PR DESCRIPTION
Adds the option to mount the nginx_secrets volume on the host