### PR TITLE
Adds bunny to approved authenticators

### DIFF
--- a/docs/certbot_authenticators.md
+++ b/docs/certbot_authenticators.md
@@ -37,6 +37,7 @@ for the supported authenticators:
  - [dns-route53][18]
  - [dns-sakuracloud][19]
  - [dns-ionos][20]
+ - [dns-bunny][21]
 
 You will need to setup the authenticator file at
 `/etc/letsencrypt/<authenticator provider>.ini`, so for e.g. Cloudflare you
@@ -133,3 +134,4 @@ authenticators.
 [18]: https://certbot-dns-route53.readthedocs.io/en/stable/#credentials
 [19]: https://certbot-dns-sakuracloud.readthedocs.io/en/stable/#credentials
 [20]: https://github.com/helgeerbe/certbot-dns-ionos
+[21]: https://github.com/mwt/certbot-dns-bunny

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -16,7 +16,8 @@ ENV CERTBOT_DNS_AUTHENTICATORS \
     rfc2136 \
     route53 \
     sakuracloud \
-    ionos
+    ionos \
+    bunny
 
 # Needed in order to install Python packages via PIP after PEP 668 was
 # introduced, but I believe this is safe since we are in a container without

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -16,7 +16,8 @@ ENV CERTBOT_DNS_AUTHENTICATORS \
     rfc2136 \
     route53 \
     sakuracloud \
-    ionos
+    ionos \
+    bunny
 
 # Do a single run command to make the intermediary containers smaller.
 RUN set -ex && \


### PR DESCRIPTION
Added bunny.net to approved authenticators. Resources:

 - Approved by certbot team as supported third party: https://github.com/certbot/certbot/issues/9374
 - Repository page: https://github.com/mwt/certbot-dns-bunny