### PR TITLE
Make sure that the logged requests also contain hostnames

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -74,6 +74,9 @@ RUN set -ex && \
 # Make sure there are no surprise config files inside the config folder.
     rm -f /etc/nginx/conf.d/*
 
+#Make sure that the container logs also show hostnames in requests.
+RUN sed -i 's/\$request\b/\$request_method \$host\$request_uri \$server_protocol/g' /etc/nginx/nginx.conf
+
 # Copy in our "default" Nginx server configurations, which make sure that the
 # ACME challenge requests are correctly forwarded to certbot and then redirects
 # everything else to HTTPS.

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -73,6 +73,9 @@ RUN set -ex && \
 # Make sure there are no surprise config files inside the config folder.
     rm -f /etc/nginx/conf.d/*
 
+#Make sure that the container logs also show hostnames in requests.
+RUN sed -i 's/\$request\b/\$request_method \$host\$request_uri \$server_protocol/g' /etc/nginx/nginx.conf
+
 # Copy in our "default" Nginx server configurations, which make sure that the
 # ACME challenge requests are correctly forwarded to certbot and then redirects
 # everything else to HTTPS.


### PR DESCRIPTION
`docker logs` showed the requests nginx received but didn't yet mention for which server they were meant.
(Mentioning this is useful because it's often a reverse proxy for multiple servers based on the name)

The default `/etc/nginx/nginx.conf` has been changed because it had to be done in the `http` block which can only be set there.
`sed` is used to replace every occurrence of `$request` _(`$request` is equal to `$request_method $request_uri $server_protocol`)_ by `$request_method $host$request_uri $server_protocol` in that file while the image is being built.