### PR TITLE
add duckdns dns-01 challenge plugin

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -17,7 +17,8 @@ ENV CERTBOT_DNS_AUTHENTICATORS \
     route53 \
     sakuracloud \
     ionos \
-    bunny
+    bunny \
+    duckdns
 
 # Needed in order to install Python packages via PIP after PEP 668 was
 # introduced, but I believe this is safe since we are in a container without

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -17,7 +17,8 @@ ENV CERTBOT_DNS_AUTHENTICATORS \
     route53 \
     sakuracloud \
     ionos \
-    bunny
+    bunny \
+    duckdns
 
 # Needed in order to install Python packages via PIP after PEP 668 was
 # introduced, but I believe this is safe since we are in a container without


### PR DESCRIPTION
Add duckdns plugin of certbot. 
The ini name is duckdns.ini though but key is `dns_duckdns_token` instead of `dns_duckdns_api_token`, which is a bit different from the certbot_authenticators.md(https://github.com/JonasAlfredsson/docker-nginx-certbot/blob/master/docs/certbot_authenticators.md)