### PR TITLE
Install latest rustc/cargo

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -24,6 +24,10 @@ ENV CERTBOT_DNS_AUTHENTICATORS \
 # any real need to cater to other programs/environments.
 ARG PIP_BREAK_SYSTEM_PACKAGES=1
 
+# We need to do some platfrom specific workarounds in the build script, so bring
+# this information in to the build environment.
+ARG TARGETPLATFORM
+
 # Through this we gain the ability to handle certbot upgrades through
 # dependabot pull requests.
 COPY requirements.txt /requirements.txt
@@ -34,7 +38,6 @@ RUN set -ex && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
             build-essential \
-            cargo \
             curl \
             libffi8 \
             libffi-dev \
@@ -45,6 +48,18 @@ RUN set -ex && \
             python3 \
             python3-dev \
     && \
+# Install the latest version of rustc/cargo if we are in an architecture that
+# needs to build the cryptography Python package.
+    if echo "$TARGETPLATFORM" | grep -E -q '^(linux/386|linux/arm64|linux/arm/v7)'; then \
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | /bin/sh -s -- -y \
+# For some reason the rustup script is unable to correctly identify the
+# environment if we are building an i386 image on an x86_64 system, so we need
+# to provide this information manually.
+        $(if [ "$TARGETPLATFORM" = "linux/386" ]; then \
+            echo "--default-host i686-unknown-linux-gnu"; \
+        fi) && \
+        . "$HOME/.cargo/env"; \
+    fi && \
 # Install the latest version of PIP, Setuptools and Wheel.
     curl -L 'https://bootstrap.pypa.io/get-pip.py' | python3 && \
 # Install certbot.
@@ -54,18 +69,19 @@ RUN set -ex && \
 # Remove everything that is no longer necessary.
     apt-get remove --purge -y \
             build-essential \
-            cargo \
             curl \
             libffi-dev \
             libssl-dev \
             pkg-config \
             python3-dev \
     && \
+    if echo "$TARGETPLATFORM" | grep -E -q '^(linux/386|linux/arm64|linux/arm/v7)'; then \
+        rustup self uninstall -y; \
+    fi && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /root/.cache && \
-    rm -rf /root/.cargo && \
 # Create new directories and set correct permissions.
     mkdir -p /var/www/letsencrypt && \
     mkdir -p /etc/nginx/user_conf.d && \

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -33,7 +33,6 @@ RUN set -ex && \
 # Install packages necessary during the build phase (for all architectures).
     apk add --no-cache \
         bash \
-        cargo \
         curl \
         findutils \
         libffi \
@@ -54,14 +53,12 @@ RUN set -ex && \
     pip3 install $(echo $CERTBOT_DNS_AUTHENTICATORS | sed 's/\(^\| \)/\1certbot-dns-/g') && \
 # Remove everything that is no longer necessary.
     apk del \
-        cargo \
         curl \
         libffi-dev \
         libressl-dev \
         python3-dev \
     && \
     rm -rf /root/.cache && \
-    rm -rf /root/.cargo && \
 # Create new directories and set correct permissions.
     mkdir -p /var/www/letsencrypt && \
     mkdir -p /etc/nginx/user_conf.d && \


### PR DESCRIPTION
The cryptography Python package requires rustc >= 1.65.0 to build now, and Debian only comes with 1.63.0 by default. We therefore utilize the rustup installation script, similar to the get-pip.py script, to get the latest version.