### PR TITLE
chore: Add Hetzner dns challenge plugin

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,6 +18,7 @@ ENV CERTBOT_DNS_AUTHENTICATORS="\
     ionos \
     bunny \
     duckdns \
+    hetzner \
     "
 
 # Needed in order to install Python packages via PIP after PEP 668 was

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -18,6 +18,7 @@ ENV CERTBOT_DNS_AUTHENTICATORS="\
     ionos \
     bunny \
     duckdns \
+    hetzner \
     "
 
 # Needed in order to install Python packages via PIP after PEP 668 was


### PR DESCRIPTION
This adds the certbot-dns-hetzner plugin.

I have been testing this change and using the resulting images internally :)

Working fine when the credentials are added to the `hetzner.ini` config file as such:
```
dns_hetzner_api_token = 0xDEADBEEF
```

Thank you for the awesome image!