### PR TITLE
Enable YAML configuration

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,0 +1,49 @@
+# Configuration for this docker image
+nginx-certbot:
+  dhparam-size: 2048
+  renewal-interval: 8d
+  debug: false
+
+# Certbot parameters.
+certbot:
+  # Default certbot authenticator (see certbots --authenticator flag). Falls back to the
+  # CERTBOT_AUTHENTICATOR environment variable or, if that is unset, to 'webroot'. The
+  # authenticator can be overriden on the certificate level.
+  authenticator: webroot
+  # Default certbot authenticator credentials (see certbots --<authenticator>-credentials
+  # flag). This is required for the various DNS authenticators. Falls back to
+  # '/etc/letsencrypt/<authenticator>.ini'.
+  credentials: ''
+  # Default elliptic curve (see certbots --elliptic-curve flag). Falls back to the
+  # ELLIPTIC_CURVE environment variable or, if that is unset, to 'secp256r1'.
+  elliptic-curve: secp256r1
+  # Default key type (see certbots --key-type flag). Falls back to 'ecdsa' (or if
+  # USE_ECDSA=0 to 'rsa'). The key type can be overriden on the certificate level.
+  key-type: ecdsa
+  # Default RSA key size (see certbots --rsa-key-size flag). Falls back to the RSA_KEY_SIZE
+  # environment variable or, if that is unset, to 2048. The key size can be overriden on the
+  # certificate level.
+  rsa-key-size: 2048
+
+# Array of certificate specifications.
+# If the 'certificates' key exist (even if the array is empty) the automatic discovery of
+# certificate names and domains is disabled and instead nginx-certbot will request
+# certificates based on the specifications in the array.
+# A minimum requirement for each certificate is to specifiy 'name' and 'domains'.
+certificates:
+    # Certificate name (see certbots --cert-name flag). Generated certificates will be
+    # placed in the /etc/letsencrypt/live/<certificate name>/ folder. This is a required
+    # parameter.
+  - name: example-com
+    # Required list of domains for which the certificate should be valid for (see certbots
+    # --domain flag). This is a required parameter.
+    domains: ["a.example.com", "b.example.com", "*.c.example.com"]
+    # Authenticator to use for this certificate. Falls back to certbot.authenticator.
+    authenticator: ''
+    # Credential file for this certificates authenticator. Falls back to
+    # certbot.credentials.
+    credentials: ''
+    # Key type for the certificate. Falls back to certbot.key-type.
+    key-type: ''
+    # RSA key size for the certificate. Falls back to certbot.rsa-key-size.
+    rsa-key-size: ''

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -71,6 +71,8 @@ RUN set -ex && \
     pip3 install -r /requirements.txt && \
 # And the supported extra authenticators.
     pip3 install $(echo $CERTBOT_DNS_AUTHENTICATORS | sed 's/\(^\| \)/\1certbot-dns-/g') && \
+# Install shyaml
+    pip3 install shyaml && \
 # Remove everything that is no longer necessary.
     apt-get remove --purge -y \
             build-essential \

--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -1,43 +1,60 @@
 #!/bin/bash
 set -e
 
-# URLs used when requesting certificates.
-# These are picked up from the environment if they are set, which enables
-# advanced usage of custom ACME servers, else it will use the default Let's
-# Encrypt servers defined here.
-: "${CERTBOT_PRODUCTION_URL=https://acme-v02.api.letsencrypt.org/directory}"
-: "${CERTBOT_STAGING_URL=https://acme-staging-v02.api.letsencrypt.org/directory}"
-
 # Source in util.sh so we can have our nice tools.
 . "$(cd "$(dirname "$0")"; pwd)/util.sh"
 
 info "Starting certificate renewal process"
 
+# If we have a config file we parse it and let definitions within take
+# precedence over any environment variables.
+config_file="${NGINX_CERTBOT_CONFIG_FILE:-/etc/nginx-certbot/config.yml}"
+if [ -f "${config_file}" ]; then
+    certbot_authenticator="$(shyaml get-value certbot.authenticator '' < "${config_file}")"
+    certbot_elliptic_curve="$(shyaml get-value certbot.elliptic-curve '' < "${config_file}")"
+    certbot_email="$(shyaml get-value certbot.email '' < "${config_file}")"
+    certbot_key_type="$(shyaml get-value certbot.key-type '' < "${config_file}")"
+    certbot_rsa_key_size="$(shyaml get-value certbot.rsa-key-size '' < "${config_file}")"
+    certbot_staging="$(shyaml get-value certbot.staging '' < "${config_file}")"
+    certbot_production_url="$(shyaml get-value certbot.production_url '' < "${config_file}")"
+    certbot_staging_url="$(shyaml get-value certbot.staging_url '' < "${config_file}")"
+fi
+
+# Environment variable fallbacks
+: "${certbot_authenticator:=${CERTBOT_AUTHENTICATOR:-webroot}}"
+: "${certbot_elliptic_curve:=${ELLIPTIC_CURVE:-secp256r1}}"
+: "${certbot_email:=${CERTBOT_EMAIL}}"
+: "${certbot_key_type:=$( [[ ${USE_ECDSA} == "0" ]] && echo "rsa" || echo "ecdsa")}"
+: "${certbot_rsa_key_size:=${RSA_KEY_SIZE:-2048}}"
+: "${certbot_staging:=${STAGING}}"
+
+# URLs used when requesting certificates.
+# These are picked up from the environment if they are set, which enables
+# advanced usage of custom ACME servers, else it will use the default Let's
+# Encrypt servers defined here.
+: "${certbot_production_url:=${CERTBOT_PRODUCTION_URL:-https://acme-v02.api.letsencrypt.org/directory}}"
+: "${certbot_staging_url:=${CERTBOT_STAGING_URL:-https://acme-staging-v02.api.letsencrypt.org/directory}}"
+
 # We require an email to be able to request a certificate.
-if [ -z "${CERTBOT_EMAIL}" ]; then
+if [ -z "${certbot_email}" ]; then
     error "CERTBOT_EMAIL environment variable undefined; certbot will do nothing!"
     exit 1
 fi
 
+# Log the global defaults we have resolved so far
+debug "Configuration resolved from config file and environment variables:"
+for var in certbot_authenticator certbot_elliptic_curve certbot_email certbot_key_type \
+    certbot_rsa_key_size certbot_staging certbot_production_url certbot_staging_url; do
+    debug "  - ${var}=${!var}"
+done
+
 # Use the correct challenge URL depending on if we want staging or not.
-if [ "${STAGING}" = "1" ]; then
+if [ "${certbot_staging}" = "1" ]; then
     debug "Using staging environment"
-    letsencrypt_url="${CERTBOT_STAGING_URL}"
+    letsencrypt_url="${certbot_staging_url}"
 else
     debug "Using production environment"
-    letsencrypt_url="${CERTBOT_PRODUCTION_URL}"
-fi
-
-# Ensure that an RSA key size is set.
-if [ -z "${RSA_KEY_SIZE}" ]; then
-    debug "RSA_KEY_SIZE unset, defaulting to 2048"
-    RSA_KEY_SIZE=2048
-fi
-
-# Ensure that an elliptic curve is set.
-if [ -z "${ELLIPTIC_CURVE}" ]; then
-    debug "ELLIPTIC_CURVE unset, defaulting to 'secp256r1'"
-    ELLIPTIC_CURVE="secp256r1"
+    letsencrypt_url="${certbot_production_url}"
 fi
 
 if [ "${1}" = "force" ]; then
@@ -53,8 +70,17 @@ fi
 # $2: String with all requested domains (e.g. -d domain.org -d www.domain.org)
 # $3: Type of key algorithm to use (rsa or ecdsa)
 # $4: The authenticator to use to solve the challenge
+# $5: The RSA key size (--rsa-key-size)
+# $6: The elliptic curve (--elliptic-curve)
+# $7: Credentials file for the authenticator
 get_certificate() {
+    local cert_name="${1}"
+    local domain_request="${2}"
+    local key_type="${3}"
     local authenticator="${4,,}"
+    local rsa_key_size="${5:-certbot_rsa_key_size}"
+    local elliptic_curve="${6:-certbot_elliptic_curve}"
+    local credentials="${7}"
     local authenticator_params=""
     local challenge_type=""
 
@@ -72,9 +98,9 @@ get_certificate() {
                 return 1
             fi
         else
-            local configfile="/etc/letsencrypt/${authenticator#dns-}.ini"
+            local configfile="${credentials:-/etc/letsencrypt/${authenticator#dns-}.ini}"
             if [ ! -f "${configfile}" ]; then
-                error "Authenticator is '${authenticator}' but '${configfile}' is missing"
+                error "Authenticator '${authenticator}' requires credentials but '${configfile}' is missing"
                 return 1
             fi
             authenticator_params="--${authenticator}-credentials=${configfile}"
@@ -84,86 +110,143 @@ get_certificate() {
             authenticator_params="${authenticator_params} --${authenticator}-propagation-seconds=${CERTBOT_DNS_PROPAGATION_SECONDS}"
         fi
     else
-        error "Unknown authenticator '${authenticator}' for '${1}'"
+        error "Unknown authenticator '${authenticator}' for '${cert_name}'"
         return 1
     fi
 
-    info "Requesting an ${3^^} certificate for '${1}' (${challenge_type} through ${authenticator})"
+    info "Requesting an ${key_type^^} certificate for '${cert_name}' (${challenge_type} through ${authenticator})"
     certbot certonly \
         --agree-tos --keep -n --text \
         --preferred-challenges ${challenge_type} \
         --authenticator ${authenticator} \
         ${authenticator_params} \
-        --email "${CERTBOT_EMAIL}" \
+        --email "${certbot_email}" \
         --server "${letsencrypt_url}" \
-        --rsa-key-size "${RSA_KEY_SIZE}" \
-        --elliptic-curve "${ELLIPTIC_CURVE}" \
-        --key-type "${3}" \
-        --cert-name "${1}" \
-        ${2} \
+        --rsa-key-size "${rsa_key_size}" \
+        --elliptic-curve "${elliptic_curve}" \
+        --key-type "${key_type}" \
+        --cert-name "${cert_name}" \
+        ${domain_request} \
         --debug ${force_renew}
 }
 
 # Get all the cert names for which we should create certificate requests and
 # have them signed, along with the corresponding server names.
-#
-# This will return an associative array that looks something like this:
-# "cert_name" => "server_name1 server_name2"
-declare -A certificates
-for conf_file in /etc/nginx/conf.d/*.conf*; do
-    parse_config_file "${conf_file}" certificates
-done
+# If we have a config file we request certificates based on the specifications
+# within that file otherwise we parse the nginx config files to automatically
+# discover certificate names, key types, authenticators, and domains.
+if [ -f "${config_file}" ]; then
+    debug "Using config file '${config_file}' for certificate specifications"
+    # Loop over the certificates array and request the certificates
+    while read -r -d '' cert; do
+        debug "Parsing certificate specification"
 
-# Iterate over each key and make a certificate request for them.
-for cert_name in "${!certificates[@]}"; do
-    server_names=(${certificates["$cert_name"]})
+        # cert-name (required)
+        cert_name="$(shyaml get-value cert-name '' <<<"${cert}")"
+        if [ -z "${cert_name}" ]; then
+            error "'cert-name' is missing; ignoring this certificate specification"
+            continue
+        fi
+        debug "Certificate cert-name is: ${cert_name}"
 
-    # Determine which type of key algorithm to use for this certificate
-    # request. Having the algorithm specified in the certificate name will
-    # take precedence over the environmental variable.
-    if [[ "${cert_name,,}" =~ (^|[-.])ecdsa([-.]|$) ]]; then
-        debug "Found variant of 'ECDSA' in name '${cert_name}"
-        key_type="ecdsa"
-    elif [[ "${cert_name,,}" =~ (^|[-.])ecc([-.]|$) ]]; then
-        debug "Found variant of 'ECC' in name '${cert_name}"
-        key_type="ecdsa"
-    elif [[ "${cert_name,,}" =~ (^|[-.])rsa([-.]|$) ]]; then
-        debug "Found variant of 'RSA' in name '${cert_name}"
-        key_type="rsa"
-    elif [ "${USE_ECDSA}" == "0" ]; then
-        key_type="rsa"
-    else
-        key_type="ecdsa"
-    fi
+        # domains (required)
+        domains=()
+        while read -r -d '' domain; do
+            domains+=("${domain}")
+        done < <(shyaml get-values-0 domains '' <<<"${cert}")
+        if [ "${#domains[@]}" -eq 0 ]; then
+            error "'domains' are missing; ignoring this certificate specification"
+            continue
+        fi
+        debug "Certificate domains are is: ${domains[*]}"
+        domain_request=""
+        for domain in "${domains[@]}"; do
+            domain_request+=" --domain ${domain}"
+        done
+        debug "Certificate domain request is: ${domain_request}"
 
-    # Determine the authenticator to use to solve the authentication challenge.
-    # Having the authenticator specified in the certificate name will take
-    # precedence over the environmental variable.
-    if [[ "${cert_name,,}" =~ (^|[-.])webroot([-.]|$) ]]; then
-        authenticator="webroot"
-        debug "Found mention of 'webroot' in name '${cert_name}"
-    elif [[ "${cert_name,,}" =~ (^|[-.])(dns-($(echo ${CERTBOT_DNS_AUTHENTICATORS} | sed 's/ /|/g')))([-.]|$) ]]; then
-        authenticator=${BASH_REMATCH[2]}
-        debug "Found mention of authenticator '${authenticator}' in name '${cert_name}'"
-    elif [ -n "${CERTBOT_AUTHENTICATOR}" ]; then
-        authenticator="${CERTBOT_AUTHENTICATOR}"
-    else
-        authenticator="webroot"
-    fi
+        # key-type (optional)
+        key_type=$(shyaml get-value key-type "${certbot_key_type}" <<<"${cert}")
+        debug "Certificate key-type is: ${key_type}"
 
-    # Assemble the list of domains to be included in the request from
-    # the parsed 'server_names'
-    domain_request=""
-    for server_name in "${server_names[@]}"; do
-        domain_request="${domain_request} -d ${server_name}"
+        # authenticator (optional)
+        authenticator=$(shyaml get-value authenticator "${certbot_authenticator}" <<<"${cert}")
+        debug "Certificate authenticator is: ${authenticator}"
+
+        # credentials (optional)
+        credentials=$(shyaml get-value credentials '' <<<"${cert}")
+        debug "Certificate authenticator credentials is: ${credentials}"
+
+        # rsa-key-size (optional)
+        rsa_key_size=$(shyaml get-value rsa-key-size "${certbot_rsa_key_size}" <<<"${cert}")
+        debug "Certificate RSA key size is: ${rsa_key_size}"
+
+        # elliptic-curve (optional)
+        elliptic_curve=$(shyaml get-value elliptic-curve "${certbot_elliptic_curve}" <<<"${cert}")
+        debug "Certificate elliptic curve is: ${elliptic_curve}"
+
+        # Hand over all the info required for the certificate request, and
+        # let certbot decide if it is necessary to update the certificate.
+        if ! get_certificate "${cert_name}" "${domain_request}" "${key_type}" "${authenticator}" "${rsa_key_size}" "${elliptic_curve}" "${credentials}"; then
+            error "Certbot failed for '${cert_name}'. Check the logs for details."
+        fi
+    done < <(shyaml -y get-values-0 certificates '' < ${config_file})
+else
+    debug "Using automatic discovery of nginx conf file for certificate specifications"
+    # This will return an associative array that looks something like this:
+    # "cert_name" => "server_name1 server_name2"
+    declare -A certificates
+    for conf_file in /etc/nginx/conf.d/*.conf*; do
+        parse_config_file "${conf_file}" certificates
     done
 
-    # Hand over all the info required for the certificate request, and
-    # let certbot decide if it is necessary to update the certificate.
-    if ! get_certificate "${cert_name}" "${domain_request}" "${key_type}" "${authenticator}"; then
-        error "Certbot failed for '${cert_name}'. Check the logs for details."
-    fi
-done
+    # Iterate over each key and make a certificate request for them.
+    for cert_name in "${!certificates[@]}"; do
+        server_names=(${certificates["$cert_name"]})
+
+        # Determine which type of key algorithm to use for this certificate
+        # request. Having the algorithm specified in the certificate name will
+        # take precedence over the environmental variable.
+        if [[ "${cert_name,,}" =~ (^|[-.])ecdsa([-.]|$) ]]; then
+            debug "Found variant of 'ECDSA' in name '${cert_name}"
+            key_type="ecdsa"
+        elif [[ "${cert_name,,}" =~ (^|[-.])ecc([-.]|$) ]]; then
+            debug "Found variant of 'ECC' in name '${cert_name}"
+            key_type="ecdsa"
+        elif [[ "${cert_name,,}" =~ (^|[-.])rsa([-.]|$) ]]; then
+            debug "Found variant of 'RSA' in name '${cert_name}"
+            key_type="rsa"
+        else
+            key_type="${certbot_key_type}"
+        fi
+
+        # Determine the authenticator to use to solve the authentication challenge.
+        # Having the authenticator specified in the certificate name will take
+        # precedence over the environmental variable.
+        if [[ "${cert_name,,}" =~ (^|[-.])webroot([-.]|$) ]]; then
+            authenticator="webroot"
+            debug "Found mention of 'webroot' in name '${cert_name}"
+        elif [[ "${cert_name,,}" =~ (^|[-.])(dns-($(echo ${CERTBOT_DNS_AUTHENTICATORS} | sed 's/ /|/g')))([-.]|$) ]]; then
+            authenticator=${BASH_REMATCH[2]}
+            debug "Found mention of authenticator '${authenticator}' in name '${cert_name}'"
+        else
+            authenticator="${certbot_authenticator}"
+        fi
+
+        # Assemble the list of domains to be included in the request from
+        # the parsed 'server_names'
+        domain_request=""
+        for server_name in "${server_names[@]}"; do
+            domain_request="${domain_request} -d ${server_name}"
+        done
+
+        # Hand over all the info required for the certificate request, and
+        # let certbot decide if it is necessary to update the certificate.
+        if ! get_certificate "${cert_name}" "${domain_request}" "${key_type}" "${authenticator}"; then
+            error "Certbot failed for '${cert_name}'. Check the logs for details."
+        fi
+    done
+fi
 
 # After trying to get all our certificates, auto enable any configs that we
 # did indeed get certificates for.


### PR DESCRIPTION
This patch allows configuring nginx-certbot with a config.yml file. In particular this allows to directly declare the certificates that should be requested by certbot with finer granularity compared to the automatic discovery based on the nginx config files.

Main motivations:

 - Currently, since automatic discovery is implemented on a per file basis, all domain names in a file are attached ot all certificates in that file. This means that for e.g.
   ```nginx
   server {
       server_name      example.com *.example.com;
       ssl_certificate  /etc/letsencrypt/live/example-com/fullchain.pem;
       # [...]
   }
   server {
       server_name      a.example.com;
       ssl_certificate  /etc/letsencrypt/live/a-example-com/fullchain.pem;
       # [...]
   }
   ```
   both `example-com` and `a-example-com` will contain the domain names `example.com`, `*.example.com`, and `a.example.com`. With this patch it is possible to instead do
   ```yaml
   certificates:
     - name: example-com
       domains: [example.com, *.example.com]
     - name: a-example-com
       domains: [a.example.com]
   ```

 - Currently the authenticator credentials can't be specified on a per certificate basis (see e.g. #315). With this patch that is possible:
   ```yaml
   certbot:
     authenticator: dns-cloudflare
   certificates:
     - name: example-com
       domains: [example.com]
       credentials: /etc/letsencrypt/example-com-cloudflare.ini
     - name: example-se
       domains: [example.se]
       credentials: /etc/letsencrypt/example-se-cloudflare.ini
   ```

 - Authenticator and key type can currently be specified on a per-certificate basis by naming them appropriately. This works okay, but it becomes a bit clunky to support more such per-certificate configurations (such as e.g. the elliptic curve or the authenticator credentials). This patch allows to directly specify everything for each certificate:
   ```yaml
   certbot:
     authenticator: dns-cloudflare
     key-type: ecdsa
     certificates:
       - name: example-com-rsa
         domains: [example.com]
         key-type: rsa
       - name: example-com
         domains: [example.com]
   ```

Since there with this patch will be a YAML config file for certificates I think it make sense to also allow configuring nginx-certbot with the same file to specify e.g. DH param size and renewal interval. This is included in the example YAML file but not implemented just yet.

The automatic disabling/enabling of nginx config files with missing certificates works just like before.

Opening this as a draft because this needs some touchups and documentation.

I hope this doesn't go too far off the "spirit" of this image. I personally don't think so at least :)