### PR TITLE
Add gandi DNS authenticator

### DIFF
--- a/docs/certbot_authenticators.md
+++ b/docs/certbot_authenticators.md
@@ -40,6 +40,7 @@ for the supported authenticators:
  - [dns-duckdns][22]
  - [hetzner][23]
  - [dns-infomaniak][24]
+ - [dns-gandi][25]
 
 You will need to setup the authenticator file at
 `/etc/letsencrypt/<authenticator provider>.ini`, so for e.g. Cloudflare you
@@ -139,3 +140,4 @@ authenticators.
 [22]: https://github.com/infinityofspace/certbot_dns_duckdns?tab=readme-ov-file#usage
 [23]: https://github.com/ctrlaltcoop/certbot-dns-hetzner?tab=readme-ov-file#credentials
 [24]: https://github.com/Infomaniak/certbot-dns-infomaniak
+[25]: https://github.com/obynio/certbot-plugin-gandi

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -22,6 +22,7 @@ ENV CERTBOT_DNS_AUTHENTICATORS="\
     infomaniak \
     namecheap \
     godaddy \
+    gandi \
     "
 
 # Needed in order to install Python packages via PIP after PEP 668 was

--- a/src/Dockerfile-alpine
+++ b/src/Dockerfile-alpine
@@ -22,6 +22,7 @@ ENV CERTBOT_DNS_AUTHENTICATORS="\
     infomaniak \
     namecheap \
     godaddy \
+    gandi \
     "
 
 # Needed in order to install Python packages via PIP after PEP 668 was


### PR DESCRIPTION
Hello! 👋

This PR adds the [dns-gandi](https://github.com/obynio/certbot-plugin-gandi) authenticator.

I have tested using a simple two-server setup sharing one wildcard certificate and it seems to work very well. Here are the output logs: [output_logs.txt](https://github.com/user-attachments/files/20546190/output_logs.txt)

Let me know if you'd like any changes 😊 And thank you for this great image!

