### PR TITLE
Ignore server_names when they look like nginx variables

### DIFF
--- a/src/scripts/util.sh
+++ b/src/scripts/util.sh
@@ -234,6 +234,12 @@ parse_config_file() {
             continue
         fi
 
+        # Ignore nginx variables since these cannot be gracefully handled
+        if [[ "${server_name}" =~ \$(.+) ]]; then
+            debug "Ignoring server name '${server_name}' since it looks like an nginx variable and we cannot handle that"
+            continue
+        fi
+
         server_names+=("${server_name}")
     done
     debug "Found the following domain names: ${server_names[*]}"


### PR DESCRIPTION
This adds a check for nginx variables when parsing server names, to make it obvious that this isn't supported.

I ran a few tests locally with the `=~ \$(.+)` check and it looks good, but I'm rusty when it comes to bash scripting so please let me know if it's not quite right.

Fixes #333.