### PR TITLE
Support for custom certificate authorities

### DIFF
--- a/src/scripts/run_certbot.sh
+++ b/src/scripts/run_certbot.sh
@@ -19,13 +19,19 @@ if [ -z "${CERTBOT_EMAIL}" ]; then
     exit 1
 fi
 
-# Use the correct challenge URL depending on if we want staging or not.
-if [ "${STAGING}" = "1" ]; then
-    debug "Using staging environment"
-    letsencrypt_url="${CERTBOT_STAGING_URL}"
+if [ ! -z "${CUSTOM_SERVER_URL}" ]
+then
+    debug "Using custom CA server at \"${CUSTOM_SERVER_URL}\""
+    letsencrypt_url="${CUSTOM_SERVER_URL}" # Not necessarily Let's Encrypt anymore though...
 else
-    debug "Using production environment"
-    letsencrypt_url="${CERTBOT_PRODUCTION_URL}"
+    # Use the correct challenge URL depending on if we want staging or not.
+    if [ "${STAGING}" = "1" ]; then
+        debug "Using staging environment"
+        letsencrypt_url="${CERTBOT_STAGING_URL}"
+    else
+        debug "Using production environment"
+        letsencrypt_url="${CERTBOT_PRODUCTION_URL}"
+    fi
 fi
 
 # Ensure that an RSA key size is set.


### PR DESCRIPTION
This option allows users to use custom CA with certbot instead of relying solely on Let's Encrypt. This option is especially useful for intranet certificate authorities.

Users who want to use this feature can simply specify the `CUSTOM_SERVER_URL` in docker compose as such:
```yaml
services:
  nginx:
    image: 'docker.io/jc21/nginx-proxy-manager:latest'
    environment:
        CUSTOM_SERVER_URL: https://acme.my-certificate-authority.com/acme/directory
```

When this option is specified, it has priority over the other server settings such as `STAGING`.

Resolves: https://github.com/NginxProxyManager/nginx-proxy-manager/issues/1417